### PR TITLE
Optimization: Time from UNIC system

### DIFF
--- a/arch/xenomai/ua_clock.c
+++ b/arch/xenomai/ua_clock.c
@@ -17,10 +17,11 @@
 # include <mach/mach.h>
 #endif
 
+extern UA_DateTime OPCUAALGetTimeStamp(void);
+extern UA_DateTime OPCUAALGetTickCount(void);
+
 UA_DateTime UA_DateTime_now(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (tv.tv_sec * UA_DATETIME_SEC) + (tv.tv_usec * UA_DATETIME_USEC) + UA_DATETIME_UNIX_EPOCH;
+	return OPCUAALGetTimeStamp();
 }
 
 /* Credit to https://stackoverflow.com/questions/13804095/get-the-time-zone-gmt-offset-in-c */
@@ -36,23 +37,7 @@ UA_Int64 UA_DateTime_localTimeUtcOffset(void) {
 }
 
 UA_DateTime UA_DateTime_nowMonotonic(void) {
-#if defined(__APPLE__) || defined(__MACH__)
-    /* OS X does not have clock_gettime, use clock_get_time */
-    clock_serv_t cclock;
-    mach_timespec_t mts;
-    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
-    clock_get_time(cclock, &mts);
-    mach_port_deallocate(mach_task_self(), cclock);
-    return (mts.tv_sec * UA_DATETIME_SEC) + (mts.tv_nsec / 100);
-#elif !defined(CLOCK_MONOTONIC_RAW)
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (ts.tv_sec * UA_DATETIME_SEC) + (ts.tv_nsec / 100);
-#else
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-    return (ts.tv_sec * UA_DATETIME_SEC) + (ts.tv_nsec / 100);
-#endif
+	return OPCUAALGetTickCount();
 }
 
 #endif /* UA_ARCHITECTURE_XENOMAI */


### PR DESCRIPTION
UA_DateTime_now and UA_DateTime_nowMonotonic now uses UNIC system
function to get the time. Uses less CPU-resources.